### PR TITLE
Fix: Middle waypoint map change

### DIFF
--- a/AssemblyCSharp/Mod/Utilities.cs
+++ b/AssemblyCSharp/Mod/Utilities.cs
@@ -109,7 +109,7 @@ namespace Mod
         {
             return waypoint.maxX < 60 ? 15 :
                 waypoint.minX > TileMap.pxw - 60 ? TileMap.pxw - 15 :
-                waypoint.minX + 30;
+                waypoint.minX + ((waypoint.maxX - waypoint.minX) / 2);
         }
 
         public static int getYWayPoint(Waypoint waypoint)


### PR DESCRIPTION
When on sayan planet trying to use the Xmap to go to the spaceship station, the Xmap would not work for begin slighted off-centered on the map pop-up

Here is a demonstration of the problem that this PR solves;

https://github.com/pk9r327/Dragonboy/assets/51760454/f527d958-db9e-45b0-a5a9-236377893cd7

